### PR TITLE
update to precondition 0.4.1 with its breaking change in 0.3.0

### DIFF
--- a/lib/src/preconditions.dart
+++ b/lib/src/preconditions.dart
@@ -7,12 +7,14 @@ import 'package:preconditions/preconditions.dart';
 
 var _log = Logger("Preconditions");
 
-final PreconditionsRepository preconditionsRepository = PreconditionsRepository();
+final PreconditionsRepository preconditionsRepository =
+    PreconditionsRepository();
 final _repo = preconditionsRepository;
 
-String preconditionIdConnected = "connected";
+var preconditionIdConnected = PreconditionId("connected");
 
-bool get preconditionIsOnline => _repo.getPrecondition(preconditionIdConnected)!.status.isSatisfied;
+bool get preconditionIsOnline =>
+    _repo.getPrecondition(preconditionIdConnected)!.status.isSatisfied;
 
 void registerAndVerifyAllPreconditions() {
   _registerOnlinePrecondition();
@@ -22,7 +24,8 @@ void registerAndVerifyAllPreconditions() {
 void _registerOnlinePrecondition() {
   FutureOr<PreconditionStatus> _isOnlineImpl() async {
     var connectivityResult = await (Connectivity().checkConnectivity());
-    if (connectivityResult == ConnectivityResult.mobile || connectivityResult == ConnectivityResult.wifi) {
+    if (connectivityResult == ConnectivityResult.mobile ||
+        connectivityResult == ConnectivityResult.wifi) {
       return PreconditionStatus.satisfied();
     }
     return PreconditionStatus.unsatisfied();
@@ -30,16 +33,19 @@ void _registerOnlinePrecondition() {
 
   FutureOr<PreconditionStatus> _isConnectedImpl() async {
     // Should be run only when "is online"
-    var connected = (await http.get(Uri.parse("https://www.gstatic.com/generate_204"))).statusCode == 204;
+    var connected =
+        (await http.get(Uri.parse("https://www.gstatic.com/generate_204")))
+                .statusCode ==
+            204;
     return PreconditionStatus.fromBoolean(connected);
   }
 
-  _repo.registerPrecondition("_online", _isOnlineImpl);
+  _repo.registerPrecondition(PreconditionId("_online"), _isOnlineImpl);
 
   _repo.registerPrecondition(
     preconditionIdConnected,
     _isConnectedImpl,
-    dependsOn: ["_online"],
+    dependsOn: [PreconditionId("__online")],
     satisfiedCache: Duration(minutes: 5),
     dependenciesStrategy: DependenciesStrategy.unsatisfiedOnUnsatisfied,
   );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -330,7 +330,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -435,7 +435,7 @@ packages:
       name: preconditions
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.4.1"
   process:
     dependency: transitive
     description:
@@ -545,7 +545,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   timing:
     dependency: transitive
     description:
@@ -566,7 +566,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   built_collection: ^5.1.1
   logging: ^1.0.2
   path_provider: ^2.0.5
-  preconditions: any
+  preconditions: ^0.4.1
   connectivity: ^3.0.6
   http: ^0.13.4
 


### PR DESCRIPTION
precondition had a breaking change:

[0.3.0] 2022-01-11
PreconditionId is now a class, not a plain String value.

The precondition is now specified as ^0.4.1, string values are replaced by PreconditionId instances. 